### PR TITLE
Workaround for invalid tracker messages

### DIFF
--- a/tools/reannounce.lua
+++ b/tools/reannounce.lua
@@ -69,7 +69,7 @@ return {
                     end
                 end
 
-                if found_matching_failure then
+                if found_matching_failure or #(peers) == 0 then
                     log.info(string.format("Sending reannounce attempt %d of %d for %s", active_timers[torrent.name].tries + 1, max_tries, torrent.name))
 
                     torrents.reannounce(torrent, {


### PR DESCRIPTION
A workaround to continue reannouncing of the tracker returns a message that isn't in match_failures or the tracker response is slow resulting in the '' response from sending an announce.