### PR TITLE
Added max_age, add_tags and remove_tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This plugin contains tools and utils for making it easier to get ahead in early
 swarms for newly announced torrents.
 
-This plugin requires Porla 0.35.1-beta.1+163 or newer. That is anything with PR #249 merged.
+This plugin requires Porla 0.35.1-beta.1+170 or newer. That is anything with PR #258 merged.
 
 ## Configuration
 
@@ -21,7 +21,10 @@ return {
         end,
 
         interval  = 7000,
-        max_tries = 18
+        max_tries = 18,
+        max_age = 3600,
+        add_tags = {"racing-failed"},
+        remove_tags = {"racing"}
     }
 }
 ```
@@ -34,5 +37,24 @@ Defaults to nil.
 Integer. Time between reannounce attempts in milliseconds. Defaults to 7000.
 
 ### `max_tries`
-Integer. Maximum number of time the plugin will attempt a reannounce.
+Integer. Maximum number of times the plugin will attempt a reannounce.
 Defaults to 18.
+
+### `max_age`
+Integer. Maximum time since the torrent was added to attempt to reannounce.
+Defaults to 3600.
+This is useful if you have more racing torrents queued than your active
+downloads setting.
+
+If either max_tries or max_age is reached the torrent will have its
+auto_managed flag set to false, be paused and have the add_tags applied and
+remove_tags removed.
+
+### `add_tags`
+Table of tags (strings). The tags to apply to the torrent if either max_tries or max_age is
+reached. Defaults to "racing-failed". If you don't want any tags added set add_tags to {}.
+
+### `remove_tags`
+Table of tags (strings). The tags to remove from a torrent if either max_tries or max_age
+is reached. No tags are removed by default.
+

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,6 +2,6 @@ main = "plugin.lua"
 
 [plugin]
 name = "racing"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Viktor Elofsson <viktor@viktorelofsson.se>"]
 homepage = "https://github.com/porla-plugins/racing"

--- a/plugin.lua
+++ b/plugin.lua
@@ -26,8 +26,11 @@ function porla.init()
                 if config.reannounce.filter(torrent) then
                     log.info(string.format("Torrent %s matched racing filter - reannouncing", name))
 
-                    local interval  = config.reannounce.interval
-                    local max_tries = config.reannounce.max_tries
+                    local interval    = config.reannounce.interval
+                    local max_tries   = config.reannounce.max_tries
+                    local max_age     = config.reannounce.max_age
+                    local add_tags    = config.reannounce.add_tags
+                    local remove_tags = config.reannounce.remove_tags
 
                     if interval == nil then
                         interval = 7000
@@ -37,7 +40,19 @@ function porla.init()
                         max_tries = 18
                     end
 
-                    reannounce.begin(torrent, interval, max_tries)
+                    if max_age == nil then
+                        max_age = 3600
+                    end
+
+                    if add_tags == nil then
+                        add_tags = {"racing-failed"}
+                    end
+
+                    if remove_tags == nil then
+                        remove_tags = {}
+                    end
+
+                    reannounce.begin(torrent, interval, max_tries, max_age, add_tags, remove_tags)
                 else
                     log.debug(string.format("Torrent %s did not match racing filter", name))
                 end

--- a/tools/reannounce.lua
+++ b/tools/reannounce.lua
@@ -5,7 +5,8 @@ local torrents = require("torrents")
 local active_timers = {}
 
 return {
-    begin = function(torrent, interval, max_tries)
+    begin = function(torrent, interval, max_tries, max_age, add_tags, remove_tags)
+
         local torrentstatus = torrent:status()
         local peers         = torrentstatus.num_peers
         local name          = torrentstatus.name
@@ -18,6 +19,15 @@ return {
         local timer = timers.new({
             interval = interval,
             callback = function()
+                if not torrent:is_valid() then
+                    log.info("Torrent doesn't exist - not reannouncing")
+
+                    active_timers[name].timer:cancel()
+                    active_timers[name] = nil
+
+                    return
+                end
+
                 log.debug(string.format("Checking if %s needs reannouncing", name))
 
                 local torrentstatus = torrent:status()
@@ -33,11 +43,33 @@ return {
                     return
                 end
 
-                if active_timers[name].tries >= max_tries then
-                    log.info(string.format("Torrent %s reached max announce tries", name))
+                local age = os.time() - torrentstatus.added_time
+
+                if (active_timers[name].tries >= max_tries) or (age > max_age) then
+                    log.info(string.format("Torrent %s reached max announce tries or age", name))
+                    local userdata = torrent:userdata()
+
+                    for _,v in pairs(add_tags) do
+                        userdata.tags:add(v)
+                    end
+
+                    for _,v in pairs(remove_tags) do
+                        userdata.tags:erase(v)
+                    end
+
+                    torrent:set_flags({
+                        auto_managed = false,
+                    })
+                    torrent:pause()
 
                     active_timers[name].timer:cancel()
                     active_timers[name] = nil
+
+                    return
+                end
+
+                if torrent:flags().paused then
+                    log.info(string.format("Torrent %s paused, not reannouncing", name))
 
                     return
                 end


### PR DESCRIPTION
Added max_age, add_tags and remove_tags configuration options.
Torrents that reach max_age or max_tries are now paused.
Fixed a bug where an active reannounce timer without a valid torrent (removed) would loop forever.